### PR TITLE
Created Blend Data Socket and Nodes; updated integer socket def value

### DIFF
--- a/addon/scripting_nodes/src/features/nodes/categories/Blend_Data/blend_data_base_node.py
+++ b/addon/scripting_nodes/src/features/nodes/categories/Blend_Data/blend_data_base_node.py
@@ -1,0 +1,38 @@
+from scripting_nodes.src.features.nodes.base_node import ScriptingBaseNode
+from scripting_nodes.src.lib.utils.sockets.modify import update_socket_type
+import bpy
+
+class BlendDataBaseNode(ScriptingBaseNode):
+
+    data_type = ""
+    data_type_plural = ""
+    
+    active_path = ""
+    data_path = ""
+
+    def update_index_type(self, context):
+        if self.index_type == "String":
+            update_socket_type(self.inputs['Index'], "ScriptingStringSocket")
+        elif self.index_type == "Integer":
+            update_socket_type(self.inputs['Index'], "ScriptingIntegerSocket")
+        self._generate()
+    
+    index_type: bpy.props.EnumProperty(name="Index Type",
+                                description="The type of index to use",
+                                items=[("Integer", "Index", "Starts at 0. Negative indices go to the back of the list."),
+                                       ("String", "Name", "Refers to the name property of the element.")],
+                                update=update_index_type)
+    
+    def draw(self, context, layout):
+        layout.prop(self, "index_type", text="text", expand=True)
+
+    def on_create(self):
+        self.add_output("ScriptingBlendDataSocket", f"All {self.data_type_plural}")
+        if self.active_path: self.add_output("ScriptingBlendDataSocket",f"Active {self.data_type}")
+        self.add_input("ScriptingIntegerSocket", "Index")
+        self.add_output("ScriptingBlendDataSocket", "Indexed")
+
+    def generate(self):
+        self.outputs[f"All {self.data_type_plural}"].code = self.data_path
+        if self.active_path: self.outputs[f"Active {self.data_type}"].code = self.active_path
+        self.outputs["Indexed"].code = f"{self.data_path}[{self.inputs['Index'].eval()}]"

--- a/addon/scripting_nodes/src/features/nodes/categories/Blend_Data/node_blend_data.py
+++ b/addon/scripting_nodes/src/features/nodes/categories/Blend_Data/node_blend_data.py
@@ -1,0 +1,271 @@
+from scripting_nodes.src.features.nodes.categories.Blend_Data.blend_data_base_node import BlendDataBaseNode
+import bpy
+
+class SNA_Node_BlendDataMaterials(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataMaterials"
+    bl_label = "Materials"
+
+    data_type = "Material"
+    data_type_plural = "Materials"
+    
+    active_path = "bpy.context.object.active_material"
+    data_path = "bpy.data.materials"
+
+
+
+class SNA_Node_BlendDataMetaballs(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataMetaballs"
+    bl_label = "Metaballs"
+
+    data_type = "Metaball"
+    data_type_plural = "Metaballs"
+    
+    data_path = "bpy.data.metaballs"
+
+
+
+class SNA_Node_BlendDataCurves(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataCurves"
+    bl_label = "Curves"
+
+    data_type = "Curve"
+    data_type_plural = "Curves"
+    
+    data_path = "bpy.data.curves"
+
+
+
+class SNA_Node_BlendDataActions(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataActions"
+    bl_label = "Actions"
+
+    data_type = "Action"
+    data_type_plural = "Actions"
+    
+    data_path = "bpy.data.actions"
+
+
+
+class SNA_Node_BlendDataArmatures(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataArmatures"
+    bl_label = "Armatures"
+
+    data_type = "Armature"
+    data_type_plural = "Armatures"
+    
+    data_path = "bpy.data.armatures"
+
+
+
+class SNA_Node_BlendDataImages(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataImages"
+    bl_label = "Images"
+
+    data_type = "Image"
+    data_type_plural = "Images"
+    
+    data_path = "bpy.data.images"
+
+
+
+class SNA_Node_BlendDataLights(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataLights"
+    bl_label = "Lights"
+
+    data_type = "Light"
+    data_type_plural = "Lights"
+    
+    data_path = "bpy.data.lights"
+
+
+
+class SNA_Node_BlendDataNodeGroups(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataNodeGroups"
+    bl_label = "Node Groups"
+
+    data_type = "Node Group"
+    data_type_plural = "Node Groups"
+    
+    data_path = "bpy.data.node_groups"
+
+
+
+class SNA_Node_BlendDataTexts(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataTexts"
+    bl_label = "Texts"
+
+    data_type = "Text"
+    data_type_plural = "Texts"
+    
+    data_path = "bpy.data.texts"
+
+
+
+class SNA_Node_BlendDataTextures(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataTextures"
+    bl_label = "Textures"
+
+    data_type = "Texture"
+    data_type_plural = "Textures"
+    
+    data_path = "bpy.data.textures"
+
+
+
+class SNA_Node_BlendDataWorkspaces(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataWorkspaces"
+    bl_label = "Workspaces"
+
+    data_type = "Workspace"
+    data_type_plural = "Workspaces"
+    
+    data_path = "bpy.data.workspaces"
+    active_path = "bpy.context.workspace"
+
+
+
+class SNA_Node_BlendDataWorlds(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataWorlds"
+    bl_label = "Worlds"
+
+    data_type = "World"
+    data_type_plural = "Worlds"
+    
+    data_path = "bpy.data.worlds"
+    active_path = "bpy.context.scene.world"
+
+
+
+class SNA_Node_BlendDataBrushes(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataBrushes"
+    bl_label = "Brushes"
+
+    data_type = "Brush"
+    data_type_plural = "Brushes"
+    
+    data_path = "bpy.data.brushes"
+
+
+
+class SNA_Node_BlendDataCameras(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataCameras"
+    bl_label = "Cameras"
+
+    data_type = "Camera"
+    data_type_plural = "Cameras"
+    
+    data_path = "bpy.data.cameras"
+    active_path = "bpy.context.scene.camera.data"
+
+
+
+class SNA_Node_BlendDataFonts(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataFonts"
+    bl_label = "Fonts"
+
+    data_type = "Font"
+    data_type_plural = "Fonts"
+    
+    data_path = "bpy.data.fonts"
+
+
+
+class SNA_Node_BlendDataGreasePencils(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataGreasePencils"
+    bl_label = "Grease Pencils"
+
+    data_type = "Grease Pencil"
+    data_type_plural = "Grease Pencils"
+    
+    data_path = "bpy.data.grease_pencils"
+
+
+
+class SNA_Node_BlendDataLattices(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataLattices"
+    bl_label = "Lattices"
+
+    data_type = "Lattice"
+    data_type_plural = "Lattices"
+    
+    data_path = "bpy.data.lattices"
+
+
+
+class SNA_Node_BlendDataScenes(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataScenes"
+    bl_label = "Scenes"
+
+    data_type = "Scene"
+    data_type_plural = "Scenes"
+    
+    data_path = "bpy.data.scenes"
+    active_path = "bpy.context.scene"
+
+
+
+class SNA_Node_BlendDataScreens(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataScreens"
+    bl_label = "Screens"
+
+    data_type = "Screen"
+    data_type_plural = "Screens"
+    
+    data_path = "bpy.data.screens"
+    active_path = "bpy.context.screen"
+
+
+
+class SNA_Node_BlendDataShapeKeys(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataShapeKeys"
+    bl_label = "Shape Keys"
+
+    data_type = "Shape Key"
+    data_type_plural = "Shape Keys"
+    
+    data_path = "bpy.data.shape_keys"
+
+
+
+class SNA_Node_BlendDataVolumes(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataVolumes"
+    bl_label = "Volumes"
+
+    data_type = "Volume"
+    data_type_plural = "Volumes"
+    
+    data_path = "bpy.data.volumes"
+
+
+
+class SNA_Node_BlendDataWindowManagers(BlendDataBaseNode, bpy.types.Node):
+
+    bl_idname = "SNA_BlendDataWindowManagers"
+    bl_label = "Window Managers"
+
+    data_type = "Window Manager"
+    data_type_plural = "Window Managers"
+    
+    data_path = "bpy.data.window_managers"
+    active_path = "bpy.context.window_manager"

--- a/addon/scripting_nodes/src/features/nodes/categories/Blend_Data/node_blender_data.py
+++ b/addon/scripting_nodes/src/features/nodes/categories/Blend_Data/node_blender_data.py
@@ -1,0 +1,19 @@
+from scripting_nodes.src.features.nodes.base_node import ScriptingBaseNode
+from scripting_nodes.src.lib.utils.sockets.modify import update_socket_type
+import bpy
+
+class SNA_Node_BlendDataBlenderData(ScriptingBaseNode, bpy.types.Node):
+    bl_idname = "SNA_BlendDataBlenderData"
+    bl_label = "Blender Data"
+
+    def on_create(self):
+        self.add_output("ScriptingBlendDataSocket", "Current Context")
+        self.add_output("ScriptingBlendDataSocket", "Blend Data")
+        self.add_output("ScriptingBlendDataSocket", "App")
+        self.add_output("ScriptingBlendDataSocket", "Path")
+
+    def generate(self):
+        self.outputs["Current Context"].code = f"bpy.context"
+        self.outputs["Blend Data"].code = f"bpy.data"
+        self.outputs["App"].code = f"bpy.app"
+        self.outputs["Path"].code = f"bpy.path"

--- a/addon/scripting_nodes/src/features/nodes/categories/Blend_Data/node_collections.py
+++ b/addon/scripting_nodes/src/features/nodes/categories/Blend_Data/node_collections.py
@@ -1,0 +1,38 @@
+from scripting_nodes.src.features.nodes.base_node import ScriptingBaseNode
+from scripting_nodes.src.lib.utils.sockets.modify import update_socket_type
+import bpy
+
+class SNA_Node_BlendDataCollections(ScriptingBaseNode, bpy.types.Node):
+    bl_idname = "SNA_BlendDataCollections"
+    bl_label = "Collections"
+
+    def update_index_type(self, context):
+        if self.index_type == "String":
+            update_socket_type(self.inputs['Index'], "ScriptingStringSocket")
+        elif self.index_type == "Integer":
+            update_socket_type(self.inputs['Index'], "ScriptingIntegerSocket")
+        self._generate()
+
+    index_type: bpy.props.EnumProperty(name="Index Type",
+                                description="The type of index to use",
+                                items=[("Integer", "Index", "Starts at 0. Negative indices go to the back of the list."),
+                                       ("String", "Name", "Refers to the name property of the element.")],
+                                update=update_index_type)
+
+    def draw(self, context, layout):
+        layout.prop(self, "index_type", text="text", expand=True)
+
+    def on_create(self):
+        self.add_output("ScriptingBlendDataSocket", "All Collections")
+        self.add_output("ScriptingBlendDataSocket", "Scene Collections")
+        self.add_output("ScriptingBlendDataSocket", "Scene Collection")
+        self.add_output("ScriptingBlendDataSocket", "Active Collection")
+        self.add_input("ScriptingIntegerSocket", "Index")
+        self.add_output("ScriptingBlendDataSocket", "Indexed")
+
+    def generate(self):
+        self.outputs["All Collections"].code = f"bpy.data.collections"
+        self.outputs["Scene Collections"].code = f"bpy.context.scene.collection.children"
+        self.outputs["Scene Collection"].code = f"bpy.context.scene.collection"
+        self.outputs["Active Collection"].code = f"bpy.context.collection"
+        self.outputs["Indexed"].code = f"bpy.data.collections[{self.inputs['Index'].eval()}]"

--- a/addon/scripting_nodes/src/features/nodes/categories/Blend_Data/node_meshes.py
+++ b/addon/scripting_nodes/src/features/nodes/categories/Blend_Data/node_meshes.py
@@ -1,0 +1,36 @@
+from scripting_nodes.src.features.nodes.base_node import ScriptingBaseNode
+from scripting_nodes.src.lib.utils.sockets.modify import update_socket_type
+import bpy
+
+class SNA_Node_BlendDataMeshes(ScriptingBaseNode, bpy.types.Node):
+    bl_idname = "SNA_BlendDataMeshes"
+    bl_label = "Meshes"
+
+    def update_index_type(self, context):
+        if self.index_type == "String":
+            update_socket_type(self.inputs['Index'], "ScriptingStringSocket")
+        elif self.index_type == "Integer":
+            update_socket_type(self.inputs['Index'], "ScriptingIntegerSocket")
+        self._generate()
+
+    index_type: bpy.props.EnumProperty(name="Index Type",
+                                description="The type of index to use",
+                                items=[("Integer", "Index", "Starts at 0. Negative indices go to the back of the list."),
+                                       ("String", "Name", "Refers to the name property of the element.")],
+                                update=update_index_type)
+
+    def draw(self, context, layout):
+        layout.prop(self, "index_type", text="text", expand=True)
+
+    def on_create(self):
+        self.add_output("ScriptingBlendDataSocket", "All Meshes")
+        self.add_output("ScriptingBlendDataSocket", "Scene Meshes")
+        self.add_input("ScriptingIntegerSocket", "Index")
+        self.add_output("ScriptingBlendDataSocket", "Active Object Mesh")
+        self.add_output("ScriptingBlendDataSocket", "Indexed")
+
+    def generate(self):
+        self.outputs["All Meshes"].code = f"bpy.data.meshes"
+        self.outputs["Scene Meshes"].code = f"list(filter(lambda obj: obj, [obj.data if obj.type == 'MESH' else None for obj in bpy.context.scene.objects]))"
+        self.outputs["Active Object Mesh"].code = f"(bpy.context.active_object.data if bpy.context.active_object.type == 'MESH' else None)"
+        self.outputs["Indexed"].code = f"bpy.data.meshes[{self.inputs['Index'].eval()}]"

--- a/addon/scripting_nodes/src/features/nodes/categories/Blend_Data/node_objects.py
+++ b/addon/scripting_nodes/src/features/nodes/categories/Blend_Data/node_objects.py
@@ -1,0 +1,38 @@
+from scripting_nodes.src.features.nodes.base_node import ScriptingBaseNode
+from scripting_nodes.src.lib.utils.sockets.modify import update_socket_type
+import bpy
+
+class SNA_Node_BlendDataObjects(ScriptingBaseNode, bpy.types.Node):
+    bl_idname = "SNA_BlendDataObjects"
+    bl_label = "Objects"
+
+    def update_index_type(self, context):
+        if self.index_type == "String":
+            update_socket_type(self.inputs['Index'], "ScriptingStringSocket")
+        elif self.index_type == "Integer":
+            update_socket_type(self.inputs['Index'], "ScriptingIntegerSocket")
+        self._generate()
+
+    index_type: bpy.props.EnumProperty(name="Index Type",
+                                description="The type of index to use",
+                                items=[("Integer", "Index", "Starts at 0. Negative indices go to the back of the list."),
+                                       ("String", "Name", "Refers to the name property of the element.")],
+                                update=update_index_type)
+
+    def draw(self, context, layout):
+        layout.prop(self, "index_type", text="text", expand=True)
+
+    def on_create(self):
+        self.add_output("ScriptingBlendDataSocket", "All Objects")
+        self.add_output("ScriptingBlendDataSocket", "Scene Objects")
+        self.add_output("ScriptingBlendDataSocket", "Selected Objects")
+        self.add_input("ScriptingIntegerSocket", "Index")
+        self.add_output("ScriptingBlendDataSocket", "Active Object")
+        self.add_output("ScriptingBlendDataSocket", "Indexed")
+
+    def generate(self):
+        self.outputs["All Objects"].code = f"bpy.data.objects"
+        self.outputs["Scene Objects"].code = f"bpy.context.scene.objects"
+        self.outputs["Selected Objects"].code = f"bpy.context.view_layer.objects.selected"
+        self.outputs["Active Object"].code = f"bpy.context.view_layer.objects.active"
+        self.outputs["Indexed"].code = f"bpy.data.objects[{self.inputs['Index'].eval()}]"

--- a/addon/scripting_nodes/src/features/sockets/data/socket_blend_data.py
+++ b/addon/scripting_nodes/src/features/sockets/data/socket_blend_data.py
@@ -1,0 +1,17 @@
+from ..base_socket import ScriptingBaseSocket
+import bpy
+
+
+class ScriptingDataSocket(ScriptingBaseSocket, bpy.types.NodeSocket):
+    bl_idname = "ScriptingBlendDataSocket"
+    bl_label = "Blend Data"
+
+    def _to_code(self):
+        return "None"
+
+    def draw(self, context, layout, node, text):
+        layout.label(text=text)
+
+    @classmethod
+    def draw_color_simple(cls):
+        return (0.0, 0.87, 0.7, 1)

--- a/addon/scripting_nodes/src/features/sockets/data/socket_integer.py
+++ b/addon/scripting_nodes/src/features/sockets/data/socket_integer.py
@@ -9,7 +9,7 @@ class ScriptingIntegerSocket(ScriptingBaseSocket, bpy.types.NodeSocket):
     def update_value(self, context):
         self.node._generate()
 
-    value: bpy.props.IntProperty(default=1, update=update_value)
+    value: bpy.props.IntProperty(default=0, update=update_value)
 
     def _to_code(self):
         return f"{self.value}"


### PR DESCRIPTION
Hey Joshua this is my first pull request over to V4 master branch. 
The main focus is simply adding blend data socket and nodes to the V4 build. I didn't know if we are keeping collection sockets or not or simply just using the standard circle socket on V4 build so all blend data sockets are just the circle socket for now.
Also, I adjusted the integer socket default value from 1 to 0. 
See all details below:

1. socket_blend_data.py 
   Created the Blend Data Socket File with teal color sockets. I just used the same structure as the data socket file.
2. socket_integer.py 
   Updated the default integer to 0 instead of 1; useful for accessing an array starting index
3. created Node Category Folder: Blend_Data 
   All of the files below were added to this category folder that handle blend data
4. blend_data_base_node.py 
   File within Blend_Data category folder 
   This base node is used by all of the classes in the next file below "node_blend_data.py"
5. node_blend_data.py 
   File within Blend_Data category folder 
   Contains the major blend data nodes (excluding objects, meshes, collections, blender data) 
   Uses the base node from blend_data_base_node.py
6. node_collections.py 
   File within Blend_Data category folder 
   Collections blend data node
7. node_meshes.py 
   File within Blend_Data category folder 
   Meshes blend data node
8. node_objects.py 
   File within Blend_Data category folder 
   Objects blend data node
9. node_blender_data.py 
   File within Blend_Data category folder 
   Blender Data blend data node