### PR TITLE
Fix: Block unconnected Execute outputs from leaking internal storage data into generated code

### DIFF
--- a/node_tree/sockets/base_socket.py
+++ b/node_tree/sockets/base_socket.py
@@ -358,8 +358,7 @@ class ScriptingSocket:
                 to_socket = self.to_sockets()
                 if to_socket:
                     return to_socket[0].python_value
-                storage_key = self._get_socket_storage_key()
-                return self.node.get(storage_key, self.default_python_value)
+                return self.default_python_value
             else:
                 # returns this program inputs python value or its default
                 storage_key = self._get_socket_storage_key()
@@ -468,9 +467,9 @@ class ScriptingSocket:
         else:
             # check validity of connection
             node_tree = getattr(self.node, "node_tree", None)
-            if not check_validity or (node_tree and node_tree.is_valid_connection(
-                self, socket
-            )):
+            if not check_validity or (
+                node_tree and node_tree.is_valid_connection(self, socket)
+            ):
                 to_sockets.append(socket)
         return to_sockets
 
@@ -493,9 +492,9 @@ class ScriptingSocket:
                     return None
             # check connection validity
             node_tree = getattr(self.node, "node_tree", None)
-            if not check_validity or (node_tree and node_tree.is_valid_connection(
-                from_out, self
-            )):
+            if not check_validity or (
+                node_tree and node_tree.is_valid_connection(from_out, self)
+            ):
                 return from_out
         return None
 


### PR DESCRIPTION
#### Problem
Internal RNA signature strings (e.g., bpy.data.images.load(...) = image: Pointer) were leaking into the generated Python code, causing syntax errors in compiled addons and cluttered node previews.

#### Root Cause
In ScriptingSocket._get_python, unconnected Program Outputs (Execute sockets) were attempting to fetch values from the node’s internal data storage. 
Storage keys (e.g., _socket_out_0_Execute) were populated with RNA ghost data. Since the sockets were unconnected, they should have been empty, but were instead injecting this data into the evaluation chain.

#### Solution
Modified node_tree/sockets/base_socket.py to force unconnected Program Outputs to always return an empty string (self.default_python_value). 

- Immediately resolves the"signature leak.
- Acts as a firewall ensuring that "Execute" wires never unintentionally contribute persistent storage data to the code generation unless they are actually connected to another node.
- Does not affect linked connections or standard Data Sockets.

Before:
<img width="998" height="982" alt="image" src="https://github.com/user-attachments/assets/5bc93ebf-489a-4c34-842a-e213a37002f2" />
After:
<img width="1056" height="1051" alt="image" src="https://github.com/user-attachments/assets/bb0e2fef-2957-4eb4-b65b-cb8d59b9ed89" />

