### PR TITLE
Default panel location to VIEW_3D

### DIFF
--- a/addon/scripting_nodes/src/features/nodes/categories/Interface/node_panel.py
+++ b/addon/scripting_nodes/src/features/nodes/categories/Interface/node_panel.py
@@ -136,6 +136,10 @@ class SNA_Node_Panel(ScriptingBaseNode, bpy.types.Node):
     )
 
     def on_create(self):
+        self.panel_space_type = "VIEW_3D"
+        self.panel_region_type = "UI"
+        self.panel_context = "NONE"
+
         # Inputs
         self.add_input("ScriptingStringSocket", "Label").value = "Panel"
         self.add_input("ScriptingBooleanSocket", "Is Visible").value = True


### PR DESCRIPTION
`items=get_space_type_items` returns `CLIP_EDITOR` as a default location for newly created panel nodes.
Most blender users wont have a clip editor open, VIEW_3D seems like a more fitting default