### PR TITLE
Batch node creation graph updates

### DIFF
--- a/node_tree/graphs/node_tree.py
+++ b/node_tree/graphs/node_tree.py
@@ -29,6 +29,12 @@ class ScriptingNodesTree(bpy.types.NodeTree):
     link_cache = (
         {}
     )  # stores cache of the links from the previous update for all node trees based on their memory adress
+    _deferred_update_generations = {}
+
+    pause_updates: bpy.props.BoolProperty(
+        default=False,
+        options={"SKIP_SAVE"},
+    )
 
     variables: bpy.props.CollectionProperty(
         type=SN_VariableProperties,
@@ -270,8 +276,25 @@ class ScriptingNodesTree(bpy.types.NodeTree):
         # update cached current links
         self.link_cache[id(self)] = curr_links
 
-        # calls a function after the links are realized
-        bpy.app.timers.register(self._update_post, first_interval=0.001)
+    def _run_deferred_update(self, tree_pointer, generation):
+        if self._deferred_update_generations.get(tree_pointer) != generation:
+            return None
+        self._deferred_update_generations.pop(tree_pointer, None)
+        if self.as_pointer() != tree_pointer:
+            return None
+        self._update_post()
+        self._update_reroutes()
+        return None
+
+    def schedule_deferred_update(self):
+        """Debounce visual/link maintenance until the current edit settles."""
+        tree_pointer = self.as_pointer()
+        generation = self._deferred_update_generations.get(tree_pointer, 0) + 1
+        self._deferred_update_generations[tree_pointer] = generation
+        bpy.app.timers.register(
+            lambda: self._run_deferred_update(tree_pointer, generation),
+            first_interval=0.001,
+        )
 
     def _update_reroutes(self):
         """Updates all inputs and display shapes of the reroutes in this node tree"""
@@ -303,9 +326,13 @@ class ScriptingNodesTree(bpy.types.NodeTree):
                     pass
 
     def update(self):
+        if self.pause_updates:
+            return
         # update tree links
         self._update_tree_links()
-        self._update_reroutes()
+        # Newly inserted reroutes do not expose their realized links until the
+        # node tree update has completed.
+        self.schedule_deferred_update()
 
     def reevaluate(self):
         """Reevaluates all nodes in this node tree"""

--- a/nodes/base_node.py
+++ b/nodes/base_node.py
@@ -18,6 +18,7 @@ def _finish_deferred_node_setup(node_tree_name, static_uid):
             node.ensure_project_unique_name()
             node.disable_evaluation = False
             node._evaluate(bpy.context)
+            node_tree.schedule_deferred_update()
             break
     return None
 
@@ -436,15 +437,21 @@ class SN_ScriptingBaseNode:
         node_ref.name = self.name
 
     def init(self, context):
-        # create node collection item
-        self._create_node_collection_item()
-        # set up custom color
-        self._set_node_color()
-        # set up the node
-        self.on_create(context)
+        node_tree = self.node_tree
+        previous_pause_updates = node_tree.pause_updates
+        node_tree.pause_updates = True
+        try:
+            # create node collection item
+            self._create_node_collection_item()
+            # set up custom color
+            self._set_node_color()
+            # set up the node
+            self.on_create(context)
+        finally:
+            node_tree.pause_updates = previous_pause_updates
         # Defer evaluation and name uniqueness check to avoid issues with Blender's 
         # internal state during node creation/paste operations.
-        node_tree_name = self.node_tree.name
+        node_tree_name = node_tree.name
         static_uid = self.static_uid
         bpy.app.timers.register(
             lambda: _finish_deferred_node_setup(node_tree_name, static_uid),
@@ -463,13 +470,19 @@ class SN_ScriptingBaseNode:
             _temporary_clipboard_node_pointers.add(self.as_pointer())
             return
 
-        # create node collection item
-        self._create_node_collection_item()
-        # set up the node
-        self.on_copy(old)
+        node_tree = self.node_tree
+        previous_pause_updates = node_tree.pause_updates
+        node_tree.pause_updates = True
+        try:
+            # create node collection item
+            self._create_node_collection_item()
+            # set up the node
+            self.on_copy(old)
+        finally:
+            node_tree.pause_updates = previous_pause_updates
         # Defer evaluation and name uniqueness check after copying to avoid issues 
         # with Blender's internal state during duplication/paste operations.
-        node_tree_name = self.node_tree.name
+        node_tree_name = node_tree.name
         static_uid = self.static_uid
         bpy.app.timers.register(
             lambda: _finish_deferred_node_setup(node_tree_name, static_uid),


### PR DESCRIPTION
## Summary

Fixes delays when adding or duplicating nodes in larger Serpens graphs.

## Cause

Node initialization creates sockets and configures properties incrementally. Each operation can trigger `ScriptingNodesTree.update()`, repeatedly performing link validation, visual maintenance, and reroute updates before the node has finished initializing.

On larger graphs, these repeated full-tree operations caused adding a single node to take several seconds.

## Implementation

Adds a temporary `pause_updates` state to `ScriptingNodesTree`.

Node creation and duplication now pause tree updates while:

- Node collection references are created.
- Node colors are configured.
- Sockets and properties are initialized.
- Copy-specific setup is performed.

The previous update state is restored using `try/finally`.

After Blender completes the node operation:

- Node evaluation runs through the existing deferred setup callback.
- Graph maintenance is scheduled once.
- A generation-based debounce discards outdated callbacks caused by rapid consecutive updates.
- Link validation, visual maintenance, and reroute updates run after the graph has settled.

This preserves existing graph behavior while removing redundant full-tree work during node initialization. The change affects editor runtime only and does not alter generated or exported addon code.