### PR TITLE
Propagate function socket renames

### DIFF
--- a/nodes/Program/Function Return.py
+++ b/nodes/Program/Function Return.py
@@ -18,9 +18,14 @@ class SN_FunctionReturnNode(SN_ScriptingBaseNode, bpy.types.Node):
         
         
     def on_dynamic_socket_add(self, socket):
+        if socket.dynamic:
+            socket = self.inputs[socket.index - 1]
         current_name = socket.name
+        used_names = [
+            inp.name for inp in self.inputs if inp != socket and not inp.dynamic
+        ]
         new_name = get_python_name(current_name, "Output", lower=False)
-        new_name = unique_collection_name(new_name, "Output", [inp.name for inp in self.inputs], "_", includes_name=True)
+        new_name = unique_collection_name(new_name, "Output", used_names, "_")
         if new_name != current_name:
             socket.set_name_silent(new_name)
         self.trigger_ref_update({ "added": socket })
@@ -43,9 +48,12 @@ class SN_FunctionReturnNode(SN_ScriptingBaseNode, bpy.types.Node):
         # Get the current name value from stored value (set by update_socket_name)
         name_storage_key = f"_socket_current_name_{id(socket)}"
         current_name = self.get(name_storage_key, socket.name)  # Fallback to socket.name if not stored
+        used_names = [
+            inp.name for inp in self.inputs if inp != socket and not inp.dynamic
+        ]
         
         new_name = get_python_name(current_name, "Output", lower=False)
-        new_name = unique_collection_name(new_name, "Output", [inp.name for inp in self.inputs], "_", includes_name=True)
+        new_name = unique_collection_name(new_name, "Output", used_names, "_")
         if new_name != current_name:
             socket.set_name_silent(new_name)
         self.trigger_ref_update({ "updated": socket, "new_name": new_name })

--- a/nodes/Program/Function Run.py
+++ b/nodes/Program/Function Run.py
@@ -60,7 +60,10 @@ class SN_RunFunctionNode(SN_ScriptingBaseNode, bpy.types.Node):
             elif "updated" in data:
                 # Use new_name from data if available, otherwise fall back to socket.name
                 socket_name = data.get("new_name", data["updated"].name)
-                self.inputs[data["updated"].index].set_name_silent(socket_name)
+                socket_index = data["updated"].index
+                sockets_in_sync = len(node.outputs) - 2 == len(self.inputs) - 1
+                if sockets_in_sync and 0 <= socket_index < len(self.inputs):
+                    self.inputs[socket_index].set_name_silent(socket_name)
             self._evaluate(bpy.context)
         elif node.bl_idname == "SN_FunctionReturnNode" and data:
             # output has been added
@@ -83,7 +86,10 @@ class SN_RunFunctionNode(SN_ScriptingBaseNode, bpy.types.Node):
             elif "updated" in data:
                 # Use new_name from data if available, otherwise fall back to socket.name
                 socket_name = data.get("new_name", data["updated"].name)
-                self.outputs[data["updated"].index].set_name_silent(socket_name)
+                socket_index = data["updated"].index
+                sockets_in_sync = len(node.inputs) - 2 == len(self.outputs) - 1
+                if sockets_in_sync and 0 <= socket_index < len(self.outputs):
+                    self.outputs[socket_index].set_name_silent(socket_name)
             self._refresh_return_connection_validation()
             self._evaluate(bpy.context)
 

--- a/nodes/Program/Function.py
+++ b/nodes/Program/Function.py
@@ -17,14 +17,18 @@ class SN_FunctionNode(SN_ScriptingBaseNode, bpy.types.Node):
         out.changeable = True
 
     def on_dynamic_socket_add(self, socket):
+        if socket.dynamic:
+            socket = self.outputs[socket.index - 1]
         current_name = socket.name
+        used_names = [
+            out.name for out in self.outputs if out != socket and not out.dynamic
+        ]
         new_name = get_python_name(current_name, "Input", lower=False)
         new_name = unique_collection_name(
             new_name,
             "Input",
-            [out.name for out in self.outputs],
+            used_names,
             "_",
-            includes_name=True,
         )
         if new_name != current_name:
             socket.set_name_silent(new_name)
@@ -47,34 +51,30 @@ class SN_FunctionNode(SN_ScriptingBaseNode, bpy.types.Node):
         self._evaluate(bpy.context)
 
     def on_socket_name_change(self, socket):
-        # Get current name value from stored value to avoid triggering callbacks
-        storage_key = f"_socket_updating_name_{id(socket)}"
-        if self.get(storage_key, False):
-            return  # Already updating, prevent recursion
+        if socket.dynamic or socket.index >= len(self.outputs) - 1:
+            return
 
-        # Get the current name value from stored value (set by update_socket_name)
         name_storage_key = f"_socket_current_name_{id(socket)}"
         current_name = self.get(
             name_storage_key, socket.name
-        )  # Fallback to socket.name if not stored
+        )
+        used_names = [
+            out.name for out in self.outputs if out != socket and not out.dynamic
+        ]
 
         new_name = get_python_name(current_name, "Input", lower=False)
         new_name = unique_collection_name(
             new_name,
             "Input",
-            [out.name for out in self.outputs],
+            used_names,
             "_",
-            includes_name=True,
         )
 
-        # Only update if the name actually changed
         if new_name != current_name:
             socket.set_name_silent(new_name)
-            # Access socket.name after set_name_silent completes (flag will be cleared)
-            # Use the new_name directly to ensure it's available for ref updates
-            socket.python_value = new_name
-            self.trigger_ref_update({"updated": socket, "new_name": new_name})
-            self._evaluate(bpy.context)
+        socket.python_value = new_name
+        self.trigger_ref_update({"updated": socket, "new_name": new_name})
+        self._evaluate(bpy.context)
 
     def update_fixed_name(self, context):
         self.trigger_ref_update()


### PR DESCRIPTION
## Summary

Fixes Function Run socket names not updating when their referenced Function socket is renamed.
Regression caused by f2fdf78f

## Cause

`Function.on_socket_name_change()` returned early because it duplicated the recursion guard already handled by the shared socket callback. It also only notified references when sanitization changed the entered name.

## Implementation

Removes the redundant guard and always updates `python_value`, notifies referenced Function Run nodes, and reevaluates the Function after resolving the final sanitized name.

This restores both normal renames and sanitized names such as `Mouse X` → `Mouse_X`.